### PR TITLE
Added LVM support into initramfs.

### DIFF
--- a/content/etc/default/xbian-initramfs
+++ b/content/etc/default/xbian-initramfs
@@ -1,3 +1,5 @@
 MAKEBACKUP=yes
 
 FORCEINITRAM=no
+
+LVM=no

--- a/content/etc/xbian-initramfs/init
+++ b/content/etc/xbian-initramfs/init
@@ -179,6 +179,15 @@ fi
 
 test -n "$CONFIG_partswap" && create_swap
 
+### LVM
+if [ -e /sbin/lvm ]; then
+    test -n "$CONFIG_splash" && /usr/bin/splash --msgtxt="detecting LVM volumes..."
+    find /lib/modules -iname dm-mod.ko | xargs -n 1 insmod
+    lvm vgscan --ignorelockingfailure
+    lvm vgchange -aly --ignorelockingfailure
+fi
+### LVM end
+
 [ -n "$CONFIG_rescue" -o -e /run/do_drop ] && drop_shell
 # root needs to be rw for network settings update
 export CONFIG_rw='rw,'

--- a/content/etc/xbian-initramfs/init
+++ b/content/etc/xbian-initramfs/init
@@ -181,10 +181,10 @@ test -n "$CONFIG_partswap" && create_swap
 
 ### LVM
 if [ -e /sbin/lvm ]; then
-    test -n "$CONFIG_splash" && /usr/bin/splash --msgtxt="detecting LVM volumes..."
-    find /lib/modules -iname dm-mod.ko | xargs -n 1 insmod
-    lvm vgscan --ignorelockingfailure
-    lvm vgchange -aly --ignorelockingfailure
+   test -n "$CONFIG_splash" && /usr/bin/splash --msgtxt="detecting LVM volumes..."
+   modprobe dm-mod
+   lvm vgscan --ignorelockingfailure
+   lvm vgchange -aly --ignorelockingfailure
 fi
 ### LVM end
 

--- a/content/etc/xbian-initramfs/update-initramfs.sh
+++ b/content/etc/xbian-initramfs/update-initramfs.sh
@@ -293,6 +293,30 @@ copy_with_libs /usr/sbin/mount.zfs
 copy_with_libs /etc/zfs/zpool.cache
 copy_with_libs /etc/modprobe.d/zfs.conf
 
+## LVM
+if [ "$LVM" = "yes" ] && [ -e /sbin/lvm ]; then
+    if [ -e /etc/lvm/lvm.conf ]; then
+	mkdir -p ./etc/lvm
+	cp /etc/lvm/lvm.conf ./etc/lvm/
+    fi
+
+    mkdir -p ./lib/udev/rules.d/
+    for rules in 56-lvm.rules 60-persistent-storage-lvm.rules; do
+	if   [ -e /etc/udev/rules.d/$rules ]; then
+	    cp -p /etc/udev/rules.d/$rules ./lib/udev/rules.d/
+	elif [ -e /lib/udev/rules.d/$rules ]; then
+	    cp -p /lib/udev/rules.d/$rules ./lib/udev/rules.d/
+	fi
+    done
+
+    copy_with_libs /sbin/dmsetup
+    copy_with_libs /sbin/lvm
+    ln -s lvm ./sbin/vgchange
+    cp -d --remove-destination -av --parents /lib/modules/$MODVER/kernel/drivers/md/dm-mod.ko ./
+    copy_modules "dm_mod"
+fi
+### LVM end
+
 need_umount=''
 if ! mountpoint -q /boot; then
         mount /boot || { echo "FATAL: /boot can't be mounted"; exit 1; }


### PR DESCRIPTION
Currently XBian has a custom kernel with LZ4 support in Btrfs. LZ4 support is not available in the mainline kernel and it means that the filesystem cannot be read outside the XBian. In case of filesystem failure, the only way to extract files from the filesystem is compiling a custom kernel or running copying on the Raspberry PI, which is very slow. Furthermore, the Btrfs is not yet marked as production ready.

Alternative option is using any other file system supported by the XBian kernel. LVM is a great addition to EXT4 for example and might be useful for people hosting the data on EXT4 rather than Btrfs.

This patch allows to embed LVM tools and kernel modules into initramfs and mount file systems located in LVM.
