### PR TITLE
F2FS needs ramfs=yes

### DIFF
--- a/content/etc/xbian-initramfs/initram.switcher.sh
+++ b/content/etc/xbian-initramfs/initram.switcher.sh
@@ -25,7 +25,7 @@ case $z in
 	esac
 	;;
     /dev/mmcblk0*|/dev/nfs)
-	grep -q vers=4 /boot/cmdline.txt && ramfs=yes || ramfs=no
+	grep -q "vers=4\|f2fs" /boot/cmdline.txt && ramfs=yes || ramfs=no
 	;;
     *)
 	ramfs=yes
@@ -44,7 +44,7 @@ elif [ $platform = iMX6 ]; then
             ramfs=yes
             ;;
         /dev/mmcblk0*|/dev/nfs)
-            grep -q vers=4 /boot/boot.scr.txt && ramfs=yes || ramfs=no
+            grep -q "vers=4\|f2fs" /boot/boot.scr.txt && ramfs=yes || ramfs=no
             ;;
         *)
             ramfs=no

--- a/content/etc/xbian-initramfs/initram.switcher.sh
+++ b/content/etc/xbian-initramfs/initram.switcher.sh
@@ -25,7 +25,7 @@ case $z in
 	esac
 	;;
     /dev/mmcblk0*|/dev/nfs)
-	grep -q "vers=4\|f2fs" /boot/cmdline.txt && ramfs=yes || ramfs=no
+	grep -q "vers=4\|rootfstype=f2fs" /boot/cmdline.txt && ramfs=yes || ramfs=no
 	;;
     *)
 	ramfs=yes
@@ -44,7 +44,7 @@ elif [ $platform = iMX6 ]; then
             ramfs=yes
             ;;
         /dev/mmcblk0*|/dev/nfs)
-            grep -q "vers=4\|f2fs" /boot/boot.scr.txt && ramfs=yes || ramfs=no
+            grep -q "vers=4\|rootfstype=f2fs" /boot/boot.scr.txt && ramfs=yes || ramfs=no
             ;;
         *)
             ramfs=no


### PR DESCRIPTION
I figured piggybacking on the NFS case should be fine. This change should remove the need to `FORCEINITRAM=yes` after cloning.